### PR TITLE
Set IFSEI send delay after connection

### DIFF
--- a/custom_components/scenario/__init__.py
+++ b/custom_components/scenario/__init__.py
@@ -74,7 +74,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry_data[IFSEI_CONF_RECONNECT_DELAY],
     )
     ifsei = IFSEI(network_config=network_configuration)
-    ifsei.set_send_delay(entry_data[CONF_DELAY])
 
     try:
         file_path = Path(hass.config.path(), YAML_DEVICES).absolute().as_posix()
@@ -96,6 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(msg, host, e) from e
 
     _LOGGER.debug("Connected to host: %s:%s, protocol: %s", host, port, protocol)
+    ifsei.set_send_delay(entry_data[CONF_DELAY])
 
     if not entry.unique_id:
         hass.config_entries.async_update_entry(entry, unique_id=ifsei.get_device_id())

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,6 @@
 """Unit tests for the scenario integration init."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 import voluptuous as vol
@@ -17,6 +17,7 @@ from custom_components.scenario import (
 from custom_components.scenario.const import (
     CONTROLLER_ENTRY,
     COVERS_ENTRY,
+    DEFAULT_SEND_DELAY,
     DOMAIN,
     IFSEI_CONF_RECONNECT,
     IFSEI_CONF_RECONNECT_DELAY,
@@ -105,6 +106,10 @@ async def test_async_setup_entry_success(
     assert mock_config_entry.state == ConfigEntryState.LOADED
     mock_ifsei.load_devices.assert_called_once_with("/fake/path")
     mock_ifsei.async_connect.assert_called_once()
+    mock_ifsei.set_send_delay.assert_called_once_with(DEFAULT_SEND_DELAY)
+    connect_index = mock_ifsei.mock_calls.index(call.async_connect())
+    delay_index = mock_ifsei.mock_calls.index(call.set_send_delay(DEFAULT_SEND_DELAY))
+    assert connect_index < delay_index
 
     entry_data = hass.data[DOMAIN][mock_config_entry.entry_id]
     assert CONTROLLER_ENTRY in entry_data


### PR DESCRIPTION
## Summary
- Call `set_send_delay` only after establishing the IFSEI connection to avoid telnet warnings
- Test that send delay is applied after connect

## Testing
- `pre-commit run --files custom_components/scenario/__init__.py tests/test_init.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b420616f74832f9c8ca9ed40922bfc