### PR TITLE
Cap coverage<7.14 to match pytest-homeassistant-custom-component pin

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 pytest-cov>=7.1.0
 pytest-homeassistant-custom-component>=0.13.331
-coverage>=7.5
+coverage>=7.5,<7.14
 mutmut>=3.5.0


### PR DESCRIPTION
pytest-homeassistant-custom-component (all releases through 0.13.333)
pins coverage==7.13.5 exactly. Allowing coverage>=7.14 makes pip's
dependency resolver fail in CI, which is what broke PR #158. Cap the
upper bound until upstream releases a build compatible with
coverage>=7.14.

https://claude.ai/code/session_01WQH8rJCfhQR5enA2sEjxUB