### PR TITLE
Improve logging and surface pyscenario library logs in Home Assistant

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -10,3 +10,4 @@ logger:
   default: info
   logs:
     custom_components.scenario: debug
+    pyscenario: debug

--- a/custom_components/scenario/__init__.py
+++ b/custom_components/scenario/__init__.py
@@ -53,6 +53,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     port = entry.data[CONF_PORT]
     protocol = Protocol[entry.data[CONF_PROTOCOL].upper()]
 
+    logging.getLogger("pyscenario").setLevel(_LOGGER.getEffectiveLevel())
+
     hass.data.setdefault(DOMAIN, {})
     entry_data = hass.data[DOMAIN].setdefault(entry.entry_id, {})
 
@@ -123,11 +125,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             reconnect=entry_data[IFSEI_CONF_RECONNECT],
             delay=entry_data[IFSEI_CONF_RECONNECT_DELAY],
         )
+        _LOGGER.debug(
+            "Options updated: send_delay=%s, reconnect=%s, reconnect_delay=%s",
+            entry_data[CONF_DELAY],
+            entry_data[IFSEI_CONF_RECONNECT],
+            entry_data[IFSEI_CONF_RECONNECT_DELAY],
+        )
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    _LOGGER.info("Setup complete for entry %s (%s:%s)", entry_id, host, port)
     return True
 
 
@@ -146,15 +155,18 @@ def _async_register_scenario_device(
     )
 
     device_registry.async_get_or_create(**device_args, config_entry_id=config_entry_id)
+    _LOGGER.debug("Registered IFSEI device %s", ifsei.get_device_id())
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload the bridge from a config entry."""
+    _LOGGER.debug("Unloading entry %s", entry.entry_id)
     entry_data = hass.data[DOMAIN][entry.entry_id]
     ifsei: IFSEI = entry_data[CONTROLLER_ENTRY]
     await ifsei.async_close()
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+    _LOGGER.info("Entry %s unloaded (ok=%s)", entry.entry_id, unload_ok)
     return unload_ok
 
 

--- a/custom_components/scenario/config_flow.py
+++ b/custom_components/scenario/config_flow.py
@@ -63,14 +63,17 @@ class ScenarioConfigFlow(ConfigFlow, domain=DOMAIN):
                 IPv4Address(user_input[CONF_HOST])
             except AddressValueError:
                 errors["base"] = "invalid_ip"
+                _LOGGER.debug("Invalid IP address: %s", user_input[CONF_HOST])
 
             # Check if is a valid port number
             try:
                 input_port = int(user_input[CONF_PORT])
                 if not (MIN_PORT_NUMBER <= input_port <= MAX_PORT_NUMBER):
                     errors["base"] = "invalid_port"
+                    _LOGGER.debug("Port out of range: %s", user_input[CONF_PORT])
             except ValueError:
                 errors["base"] = "invalid_port"
+                _LOGGER.debug("Invalid port value: %s", user_input[CONF_PORT])
 
             if not errors:
                 ifsei = IFSEI(
@@ -84,6 +87,12 @@ class ScenarioConfigFlow(ConfigFlow, domain=DOMAIN):
                 controller_unique_id = ifsei.get_device_id()
                 await self.async_set_unique_id(controller_unique_id)
                 self._abort_if_unique_id_configured()
+                _LOGGER.info(
+                    "Creating entry for controller %s at %s:%s",
+                    controller_unique_id,
+                    user_input[CONF_HOST],
+                    user_input[CONF_PORT],
+                )
                 return self.async_create_entry(
                     title=controller_unique_id,
                     data={
@@ -115,6 +124,12 @@ class ScenarioOptionsFlowHandler(OptionsFlow):
     ) -> ConfigFlowResult:
         """Handle options flow."""
         if user_input is not None:
+            _LOGGER.debug(
+                "Options updated: delay=%s, reconnect=%s, reconnect_delay=%s",
+                user_input[CONF_DELAY],
+                user_input[IFSEI_CONF_RECONNECT],
+                user_input[IFSEI_CONF_RECONNECT_DELAY],
+            )
             return self.async_create_entry(
                 title="",
                 data={

--- a/custom_components/scenario/cover.py
+++ b/custom_components/scenario/cover.py
@@ -75,23 +75,26 @@ class ScenarioCover(ScenarioUpdatableEntity, CoverEntity):
     async def async_open_cover(self) -> None:
         """Open the cover."""
         if self.unique_id is not None:
+            _LOGGER.debug("Opening cover %s", self.name)
             await self._ifsei.async_update_cover_state(self.unique_id, int(self.up))
         else:
-            _LOGGER.debug("Missing device unique id")
+            _LOGGER.warning("Missing device unique id")
 
     async def async_close_cover(self) -> None:
         """Close the cover."""
         if self.unique_id is not None:
+            _LOGGER.debug("Closing cover %s", self.name)
             await self._ifsei.async_update_cover_state(self.unique_id, int(self.down))
         else:
-            _LOGGER.debug("Missing device unique id")
+            _LOGGER.warning("Missing device unique id")
 
     async def async_stop_cover(self) -> None:
         """Stop the cover."""
         if self.unique_id is not None:
+            _LOGGER.debug("Stopping cover %s", self.name)
             await self._ifsei.async_update_cover_state(self.unique_id, int(self.stop))
         else:
-            _LOGGER.debug("Missing device unique id")
+            _LOGGER.warning("Missing device unique id")
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove callbacks."""
@@ -105,8 +108,12 @@ class ScenarioCover(ScenarioUpdatableEntity, CoverEntity):
 
         if available is not None:
             self._attr_available = available
+            _LOGGER.debug("Set cover %s availability to %s", self.name, available)
 
         if command is not None and state is not None:
+            _LOGGER.debug(
+                "Cover %s received command=%s, state=%s", self.name, command, state
+            )
             if command == IFSEI_COVER_DOWN and state == IFSEI_ATTR_SCENE_ACTIVE:
                 self._attr_is_closed = True
             elif command == IFSEI_COVER_UP and state == IFSEI_ATTR_SCENE_ACTIVE:

--- a/custom_components/scenario/light.py
+++ b/custom_components/scenario/light.py
@@ -101,7 +101,7 @@ class ScenarioLight(ScenarioUpdatableEntity, LightEntity):
 
         if rgbw is not None:
             colors = list(rgbw)
-            _LOGGER.debug(f"Current color: {colors}")  # noqa: G004
+            _LOGGER.debug("Current color: %s", colors)
             scaled_colors[0] = to_scenario_level(colors[0])
             scaled_colors[1] = to_scenario_level(colors[1])
             scaled_colors[2] = to_scenario_level(colors[2])
@@ -111,9 +111,14 @@ class ScenarioLight(ScenarioUpdatableEntity, LightEntity):
 
         if self._ifsei.device_manager is not None and self._attr_unique_id is not None:
             _LOGGER.debug("Setting color: %s", scaled_colors)
-            # Update light state
             await self._ifsei.async_update_light_state(
                 self._attr_unique_id, scaled_colors
+            )
+        else:
+            _LOGGER.warning(
+                "Cannot set brightness: device_manager=%s, unique_id=%s",
+                self._ifsei.device_manager is not None,
+                self._attr_unique_id,
             )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -123,10 +128,12 @@ class ScenarioLight(ScenarioUpdatableEntity, LightEntity):
         if brightness is None:
             brightness = 255
 
+        _LOGGER.debug("Turning on light %s (brightness=%s)", self.name, brightness)
         await self._async_set_brightness(brightness, **kwargs)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
+        _LOGGER.debug("Turning off light %s", self.name)
         await self._async_set_brightness(0, **kwargs)
 
     async def async_will_remove_from_hass(self) -> None:

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -103,21 +103,21 @@ async def test_missing_unique_id_for_commands(
     """
     Test scenario where unique_id is None.
 
-    Commands should log a debug message instead of calling async_update_cover_state.
+    Commands should log a warning instead of calling async_update_cover_state.
     """
     mock_cover.unique_id = None
     entity = ScenarioCover(mock_cover, mock_ifsei)
     entity.hass = hass
 
-    with patch("logging.Logger.debug") as mock_log:
+    with patch("logging.Logger.warning") as mock_log:
         await entity.async_open_cover()
         mock_log.assert_any_call("Missing device unique id")
 
-    with patch("logging.Logger.debug") as mock_log:
+    with patch("logging.Logger.warning") as mock_log:
         await entity.async_close_cover()
         mock_log.assert_any_call("Missing device unique id")
 
-    with patch("logging.Logger.debug") as mock_log:
+    with patch("logging.Logger.warning") as mock_log:
         await entity.async_stop_cover()
         mock_log.assert_any_call("Missing device unique id")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Unit tests for the scenario integration init."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -467,3 +468,32 @@ async def test_scenario_updatable_entity_with_disconnected_ifsei() -> None:
 
     # Entity should reflect that IFSEI is not connected
     assert entity.available is False
+
+
+@pytest.mark.asyncio
+async def test_pyscenario_logger_level_is_set(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_ifsei: MagicMock,
+) -> None:
+    """Test that pyscenario logger level is set to match integration level."""
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch("custom_components.scenario.IFSEI", return_value=mock_ifsei),
+        patch("custom_components.scenario.Path") as mock_path,
+        patch(
+            "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
+            return_value=None,
+        ),
+    ):
+        mock_path.return_value.as_posix.return_value = "/fake/path"
+
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state == ConfigEntryState.LOADED
+
+    pyscenario_logger = logging.getLogger("pyscenario")
+    integration_logger = logging.getLogger("custom_components.scenario")
+    assert pyscenario_logger.level == integration_logger.getEffectiveLevel()


### PR DESCRIPTION
Set the pyscenario logger level to match the integration's effective
level during setup, so pyscenario connection, command, and device state
logs appear in HA without extra user configuration. Also add lifecycle
logging (setup completion, unload, options update, device registration),
cover state change and availability logging, config flow validation
logging, and fix the f-string logging violation in light.py. Upgrade
"Missing device unique id" from debug to warning since it indicates a
configuration problem.

https://claude.ai/code/session_01KKXLQC6Y5WXL6FE9QCtP1h