### PR TITLE
feat: cover position tracking via physical relay feedback (pyscenario 1.0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage.xml
 .venv
 .claude
 .mutmut-cache
+.antigravitycli
 
 
 # Home Assistant configuration

--- a/config/scenario_device_config.yaml
+++ b/config/scenario_device_config.yaml
@@ -497,9 +497,9 @@ shades:
   - id: 5
     name: Persiana LE
     zone: 5
-    address1: "0102"
+    address1: "0104"
     address2: "0103"
-    address3: "0104"
+    address3: "0102"
     module: 1
     open_channel: 6
     close_channel: 5

--- a/config/scenario_device_config.yaml
+++ b/config/scenario_device_config.yaml
@@ -464,33 +464,51 @@ shades:
     address1: "0002"
     address2: "0003"
     address3: "0004"
+    module: 0
+    open_channel: 1
+    close_channel: 2
   - id: 2
     name: Persiana LD
     zone: 10
     address1: "0005"
     address2: "0006"
     address3: "0007"
+    module: 0
+    open_channel: 3
+    close_channel: 4
   - id: 3
     name: Persiana LE
     zone: 10
     address1: "0008"
     address2: "0009"
     address3: "0010"
+    module: 0
+    open_channel: 5
+    close_channel: 6
   - id: 4
     name: Persiana LD
     zone: 5
     address1: "0013"
     address2: "0014"
     address3: "0015"
+    module: 0
+    open_channel: 7
+    close_channel: 8
   - id: 5
     name: Persiana LE
     zone: 5
     address1: "0102"
     address2: "0103"
     address3: "0104"
+    module: 1
+    open_channel: 6
+    close_channel: 5
   - id: 6
     name: Persiana Lateral
     zone: 5
     address1: "0105"
     address2: "0106"
     address3: "0107"
+    module: 1
+    open_channel: 7
+    close_channel: 8

--- a/custom_components/scenario/cover.py
+++ b/custom_components/scenario/cover.py
@@ -77,6 +77,7 @@ class ScenarioCover(ScenarioUpdatableEntity, CoverEntity):
 
         if not self._has_relay_feedback:
             self.assumed_state = True
+            self._attr_is_closed = None
 
         self._device.add_subscriber(self.async_update_callback)
 

--- a/custom_components/scenario/cover.py
+++ b/custom_components/scenario/cover.py
@@ -33,7 +33,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TRAVEL_TIME = 30.0
 RELAY_ACTIVE = 100
-POSITION_MAX = 100
 POSITION_MIN = 0
 
 
@@ -120,29 +119,25 @@ class ScenarioCover(ScenarioUpdatableEntity, CoverEntity):
             return self._current_position == 0
         return self._attr_is_closed
 
-    async def async_open_cover(self) -> None:
-        """Open the cover."""
+    async def _send_cover_command(self, address: str, action: str) -> None:
+        """Send a cover command to the IFSEI controller."""
         if self.unique_id is not None:
-            _LOGGER.debug("Opening cover %s", self.name)
-            await self._ifsei.async_update_cover_state(self.unique_id, int(self.up))
+            _LOGGER.debug("%s cover %s", action, self.name)
+            await self._ifsei.async_update_cover_state(self.unique_id, int(address))
         else:
             _LOGGER.warning("Missing device unique id")
+
+    async def async_open_cover(self) -> None:
+        """Open the cover."""
+        await self._send_cover_command(self.up, "Opening")
 
     async def async_close_cover(self) -> None:
         """Close the cover."""
-        if self.unique_id is not None:
-            _LOGGER.debug("Closing cover %s", self.name)
-            await self._ifsei.async_update_cover_state(self.unique_id, int(self.down))
-        else:
-            _LOGGER.warning("Missing device unique id")
+        await self._send_cover_command(self.down, "Closing")
 
     async def async_stop_cover(self) -> None:
         """Stop the cover."""
-        if self.unique_id is not None:
-            _LOGGER.debug("Stopping cover %s", self.name)
-            await self._ifsei.async_update_cover_state(self.unique_id, int(self.stop))
-        else:
-            _LOGGER.warning("Missing device unique id")
+        await self._send_cover_command(self.stop, "Stopping")
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move cover to a target position."""
@@ -155,64 +150,56 @@ class ScenarioCover(ScenarioUpdatableEntity, CoverEntity):
             await self.async_open_cover()
         else:
             await self.async_close_cover()
-        self.hass.loop.call_later(
-            travel_duration,
-            lambda: self.hass.async_create_task(self.async_stop_cover()),
-        )
+
+        def _schedule_stop() -> None:
+            self.hass.async_create_task(self.async_stop_cover())
+
+        self.hass.loop.call_later(travel_duration, _schedule_stop)
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove callbacks."""
         self._device.remove_subscriber()
 
-    def _handle_open_relay(self, value: int, now: float) -> None:
-        """Process open relay state change."""
-        if value == RELAY_ACTIVE:
-            _LOGGER.debug("%s: Open relay energised", self.name)
-            self._is_opening = True
-            self._is_closing = False
-            self._last_relay_on_time = now
-        else:
-            _LOGGER.debug("%s: Open relay de-energised", self.name)
-            if self._is_opening and self._last_relay_on_time is not None:
-                elapsed = now - self._last_relay_on_time
-                delta = (elapsed / self._travel_time) * 100
-                self._current_position = min(
-                    POSITION_MAX, int(self._current_position + delta)
-                )
-                _LOGGER.info(
-                    "%s: Moved up %.2fs (+%d%%). Position: %d%%",
-                    self.name,
-                    elapsed,
-                    delta,
-                    self._current_position,
-                )
-            self._is_opening = False
-            self._last_relay_on_time = None
+    def _handle_relay(self, value: int, now: float, *, opening: bool) -> None:
+        """Process a relay state change for either open or close direction."""
+        is_active_flag = self._is_opening if opening else self._is_closing
+        direction_label = "Open" if opening else "Close"
+        move_label = "up" if opening else "down"
+        sign = 1 if opening else -1
 
-    def _handle_close_relay(self, value: int, now: float) -> None:
-        """Process close relay state change."""
         if value == RELAY_ACTIVE:
-            _LOGGER.debug("%s: Close relay energised", self.name)
-            self._is_closing = True
-            self._is_opening = False
+            _LOGGER.debug("%s: %s relay energised", self.name, direction_label)
+            self._is_opening = opening
+            self._is_closing = not opening
             self._last_relay_on_time = now
         else:
-            _LOGGER.debug("%s: Close relay de-energised", self.name)
-            if self._is_closing and self._last_relay_on_time is not None:
+            _LOGGER.debug("%s: %s relay de-energised", self.name, direction_label)
+            if is_active_flag and self._last_relay_on_time is not None:
                 elapsed = now - self._last_relay_on_time
                 delta = (elapsed / self._travel_time) * 100
                 self._current_position = max(
-                    POSITION_MIN, int(self._current_position - delta)
+                    POSITION_MIN,
+                    min(RELAY_ACTIVE, int(self._current_position + sign * delta)),
                 )
                 _LOGGER.info(
-                    "%s: Moved down %.2fs (-%d%%). Position: %d%%",
+                    "%s: Moved %s %.2fs (%+d%%). Position: %d%%",
                     self.name,
+                    move_label,
                     elapsed,
-                    delta,
+                    sign * delta,
                     self._current_position,
                 )
+            self._is_opening = False
             self._is_closing = False
             self._last_relay_on_time = None
+
+    def _handle_open_relay(self, value: int, now: float) -> None:
+        """Process open relay state change."""
+        self._handle_relay(value, now, opening=True)
+
+    def _handle_close_relay(self, value: int, now: float) -> None:
+        """Process close relay state change."""
+        self._handle_relay(value, now, opening=False)
 
     def _handle_scene_command(self, command: str, state: str) -> None:
         """Process legacy scene command (covers without relay feedback)."""

--- a/custom_components/scenario/cover.py
+++ b/custom_components/scenario/cover.py
@@ -1,9 +1,11 @@
 """Platform for Scenario Covers."""
 
 import logging
+import time
 from typing import Any
 
 from homeassistant.components.cover import (
+    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -29,6 +31,11 @@ from .const import CONTROLLER_ENTRY, COVERS_ENTRY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_TRAVEL_TIME = 30.0
+RELAY_ACTIVE = 100
+POSITION_MAX = 100
+POSITION_MIN = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -44,23 +51,41 @@ async def async_setup_entry(
 class ScenarioCover(ScenarioUpdatableEntity, CoverEntity):
     """Scenario Cover Entity."""
 
-    _attr_supported_features = (
-        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
-    )
     _attr_device_class = CoverDeviceClass.SHADE
 
-    def __init__(self, cover: Cover, ifsei: IFSEI) -> None:
-        """Initialize a scenario light."""
+    def __init__(
+        self, cover: Cover, ifsei: IFSEI, travel_time: float = DEFAULT_TRAVEL_TIME
+    ) -> None:
+        """Initialize a scenario cover."""
         super().__init__(cover, ifsei)
         self.up = cover.up
         self.stop = cover.stop
         self.down = cover.down
-        self._attr_is_closed = True
+        self._travel_time = travel_time
         self._attr_available = ifsei.is_connected
 
-        # Allow all commands to be enabled (no half-open / half-closed state allowed)
-        self.assumed_state = True
+        self._has_relay_feedback = (
+            cover.module is not None
+            and cover.open_channel is not None
+            and cover.close_channel is not None
+        )
+
+        self._current_position: int = 50
+        self._is_opening: bool = False
+        self._is_closing: bool = False
+        self._last_relay_on_time: float | None = None
+
         self._device.add_subscriber(self.async_update_callback)
+
+    @property
+    def supported_features(self) -> CoverEntityFeature:
+        """Return supported features."""
+        features = (
+            CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+        )
+        if self._has_relay_feedback:
+            features |= CoverEntityFeature.SET_POSITION
+        return features
 
     @property
     def ifsei(self) -> IFSEI:
@@ -68,8 +93,27 @@ class ScenarioCover(ScenarioUpdatableEntity, CoverEntity):
         return self._ifsei
 
     @property
+    def current_cover_position(self) -> int | None:
+        """Return current position. 0=closed, 100=open."""
+        if self._has_relay_feedback:
+            return self._current_position
+        return None
+
+    @property
+    def is_opening(self) -> bool:
+        """Return true if cover is opening."""
+        return self._is_opening
+
+    @property
+    def is_closing(self) -> bool:
+        """Return true if cover is closing."""
+        return self._is_closing
+
+    @property
     def is_closed(self) -> bool | None:
-        """Return true if cover is closed."""
+        """Return true if cover is fully closed."""
+        if self._has_relay_feedback:
+            return self._current_position == 0
         return self._attr_is_closed
 
     async def async_open_cover(self) -> None:
@@ -96,33 +140,120 @@ class ScenarioCover(ScenarioUpdatableEntity, CoverEntity):
         else:
             _LOGGER.warning("Missing device unique id")
 
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Move cover to a target position."""
+        target = kwargs[ATTR_POSITION]
+        diff = target - self._current_position
+        if diff == 0:
+            return
+        travel_duration = abs(diff) / 100.0 * self._travel_time
+        if diff > 0:
+            await self.async_open_cover()
+        else:
+            await self.async_close_cover()
+        self.hass.loop.call_later(
+            travel_duration,
+            lambda: self.hass.async_create_task(self.async_stop_cover()),
+        )
+
     async def async_will_remove_from_hass(self) -> None:
         """Remove callbacks."""
         self._device.remove_subscriber()
 
+    def _handle_open_relay(self, value: int, now: float) -> None:
+        """Process open relay state change."""
+        if value == RELAY_ACTIVE:
+            _LOGGER.debug("%s: Open relay energised", self.name)
+            self._is_opening = True
+            self._is_closing = False
+            self._last_relay_on_time = now
+        else:
+            _LOGGER.debug("%s: Open relay de-energised", self.name)
+            if self._is_opening and self._last_relay_on_time is not None:
+                elapsed = now - self._last_relay_on_time
+                delta = (elapsed / self._travel_time) * 100
+                self._current_position = min(
+                    POSITION_MAX, int(self._current_position + delta)
+                )
+                _LOGGER.info(
+                    "%s: Moved up %.2fs (+%d%%). Position: %d%%",
+                    self.name,
+                    elapsed,
+                    delta,
+                    self._current_position,
+                )
+            self._is_opening = False
+            self._last_relay_on_time = None
+
+    def _handle_close_relay(self, value: int, now: float) -> None:
+        """Process close relay state change."""
+        if value == RELAY_ACTIVE:
+            _LOGGER.debug("%s: Close relay energised", self.name)
+            self._is_closing = True
+            self._is_opening = False
+            self._last_relay_on_time = now
+        else:
+            _LOGGER.debug("%s: Close relay de-energised", self.name)
+            if self._is_closing and self._last_relay_on_time is not None:
+                elapsed = now - self._last_relay_on_time
+                delta = (elapsed / self._travel_time) * 100
+                self._current_position = max(
+                    POSITION_MIN, int(self._current_position - delta)
+                )
+                _LOGGER.info(
+                    "%s: Moved down %.2fs (-%d%%). Position: %d%%",
+                    self.name,
+                    elapsed,
+                    delta,
+                    self._current_position,
+                )
+            self._is_closing = False
+            self._last_relay_on_time = None
+
+    def _handle_scene_command(self, command: str, state: str) -> None:
+        """Process legacy scene command (covers without relay feedback)."""
+        _LOGGER.debug(
+            "Cover %s received command=%s, state=%s", self.name, command, state
+        )
+        if self._has_relay_feedback:
+            return
+        if command == IFSEI_COVER_DOWN and state == IFSEI_ATTR_SCENE_ACTIVE:
+            self._attr_is_closed = True
+        elif command == IFSEI_COVER_UP and state == IFSEI_ATTR_SCENE_ACTIVE:
+            self._attr_is_closed = False
+        elif command == IFSEI_COVER_STOP and state in (
+            IFSEI_ATTR_SCENE_ACTIVE,
+            IFSEI_ATTR_SCENE_INACTIVE,
+        ):
+            self._attr_is_closing = False
+            self._attr_is_opening = False
+
     def async_update_callback(self, **kwargs: Any) -> None:
         """Update callback."""
         available = kwargs.pop(IFSEI_ATTR_AVAILABLE, None)
+        open_relay = kwargs.pop("open_relay", None)
+        close_relay = kwargs.pop("close_relay", None)
         command = kwargs.pop(IFSEI_ATTR_COMMAND, None)
         state = kwargs.pop(IFSEI_ATTR_STATE, None)
+        now = time.time()
+        state_changed = False
 
         if available is not None:
             self._attr_available = available
             _LOGGER.debug("Set cover %s availability to %s", self.name, available)
+            state_changed = True
+
+        if open_relay is not None:
+            self._handle_open_relay(open_relay, now)
+            state_changed = True
+
+        if close_relay is not None:
+            self._handle_close_relay(close_relay, now)
+            state_changed = True
 
         if command is not None and state is not None:
-            _LOGGER.debug(
-                "Cover %s received command=%s, state=%s", self.name, command, state
-            )
-            if command == IFSEI_COVER_DOWN and state == IFSEI_ATTR_SCENE_ACTIVE:
-                self._attr_is_closed = True
-            elif command == IFSEI_COVER_UP and state == IFSEI_ATTR_SCENE_ACTIVE:
-                self._attr_is_closed = False
-            elif command == IFSEI_COVER_STOP and state in (
-                IFSEI_ATTR_SCENE_ACTIVE,
-                IFSEI_ATTR_SCENE_INACTIVE,
-            ):
-                self._attr_is_closing = False
-                self._attr_is_opening = False
+            self._handle_scene_command(command, state)
+            state_changed = True
 
-        self.async_write_ha_state()
+        if state_changed:
+            self.async_write_ha_state()

--- a/custom_components/scenario/cover.py
+++ b/custom_components/scenario/cover.py
@@ -75,6 +75,9 @@ class ScenarioCover(ScenarioUpdatableEntity, CoverEntity):
         self._is_closing: bool = False
         self._last_relay_on_time: float | None = None
 
+        if not self._has_relay_feedback:
+            self.assumed_state = True
+
         self._device.add_subscriber(self.async_update_callback)
 
     @property

--- a/custom_components/scenario/manifest.json
+++ b/custom_components/scenario/manifest.json
@@ -11,9 +11,9 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/carlosmazzei/scenario/issues",
   "requirements": [
-    "pyscenario==1.0.0"
+    "pyscenario==1.0.1"
   ],
   "ssdp": [],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "zeroconf": []
 }

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -304,7 +304,7 @@ def test_properties_with_relay(scenario_cover_relay: ScenarioCover) -> None:
     assert scenario_cover_relay.current_cover_position == 50  # noqa: PLR2004
     assert scenario_cover_relay.is_opening is False
     assert scenario_cover_relay.is_closing is False
-    assert scenario_cover_relay.is_closed is False  # position=50 != 0
+    assert scenario_cover_relay.is_closed is False
 
 
 def test_open_relay_on(scenario_cover_relay: ScenarioCover) -> None:

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -33,6 +33,9 @@ def mock_cover() -> MagicMock:
     cover.up = "0002"
     cover.down = "0003"
     cover.stop = "0004"
+    cover.module = None
+    cover.open_channel = None
+    cover.close_channel = None
     return cover
 
 
@@ -138,8 +141,8 @@ def test_properties(scenario_cover: ScenarioCover) -> None:
     )
     assert scenario_cover.device_class == CoverDeviceClass.SHADE
     assert scenario_cover.assumed_state is True
-    # Initially True, as set in __init__:
-    assert scenario_cover.is_closed is True
+    # No relay feedback: is_closed returns _attr_is_closed (None initially)
+    assert scenario_cover.is_closed is None
     # Verify individual properties
     assert scenario_cover.up == "0002"
     assert scenario_cover.down == "0003"
@@ -152,7 +155,8 @@ def test_update_callback_down_active(scenario_cover: ScenarioCover) -> None:
     Test update callback.
 
     Test update callback when the cover command is 'down'
-    and state is 'scene active' -> sets is_closed to True.
+    and state is 'scene active' -> sets _attr_is_closed to True.
+    Only applies to covers without relay feedback.
     """
     with patch.object(scenario_cover, "async_write_ha_state") as mock_write_state:
         scenario_cover.async_update_callback(
@@ -162,7 +166,7 @@ def test_update_callback_down_active(scenario_cover: ScenarioCover) -> None:
                 IFSEI_ATTR_STATE: IFSEI_ATTR_SCENE_ACTIVE,
             }
         )
-        assert scenario_cover.is_closed is True
+        assert scenario_cover._attr_is_closed is True
         assert scenario_cover.available is True
         mock_write_state.assert_called_once()
 
@@ -192,9 +196,10 @@ def test_update_callback_stop_active(scenario_cover: ScenarioCover) -> None:
     Test update callback.
 
     Test update callback when command is 'stop' and state is
-    'scene active' or 'scene inactive' -> set is_closing/is_opening = False.
+    'scene active' or 'scene inactive' -> set _attr_is_closing/_attr_is_opening = False.
+    Only applies to covers without relay feedback.
     """
-    # Force is_closing/is_opening to True for test
+    # Force _attr_is_closing/_attr_is_opening to True for test
     scenario_cover._attr_is_closing = True
     scenario_cover._attr_is_opening = True
 
@@ -236,7 +241,7 @@ def test_update_callback_only_availability(scenario_cover: ScenarioCover) -> Non
 
 
 def test_update_callback_none_values(scenario_cover: ScenarioCover) -> None:
-    """Test update callback with None values doesn't change state."""
+    """Test update callback with None values doesn't change state or write HA state."""
     initial_closed_state = scenario_cover.is_closed
     with patch.object(scenario_cover, "async_write_ha_state") as mock_write_state:
         scenario_cover.async_update_callback(
@@ -246,16 +251,121 @@ def test_update_callback_none_values(scenario_cover: ScenarioCover) -> None:
             }
         )
         assert scenario_cover.is_closed == initial_closed_state
-        mock_write_state.assert_called_once()
+        mock_write_state.assert_not_called()
 
 
 def test_update_callback_command_without_state(scenario_cover: ScenarioCover) -> None:
-    """Test update callback with command but no state."""
+    """Test update callback with command but no state does not write HA state."""
     initial_closed_state = scenario_cover.is_closed
     with patch.object(scenario_cover, "async_write_ha_state") as mock_write_state:
         scenario_cover.async_update_callback(**{IFSEI_ATTR_COMMAND: IFSEI_COVER_DOWN})
         assert scenario_cover.is_closed == initial_closed_state
-        mock_write_state.assert_called_once()
+        mock_write_state.assert_not_called()
+
+
+@pytest.fixture
+def mock_cover_with_relay() -> MagicMock:
+    """Create a mock cover fixture with relay feedback configured."""
+    cover = MagicMock()
+    cover.unique_id = "test_cover_relay_id"
+    cover.up = "0008"
+    cover.down = "0010"
+    cover.stop = "0009"
+    cover.module = 0
+    cover.open_channel = 5
+    cover.close_channel = 6
+    return cover
+
+
+@pytest.fixture
+async def scenario_cover_relay(
+    hass: HomeAssistant, mock_cover_with_relay: MagicMock, mock_ifsei: MagicMock
+) -> ScenarioCover:
+    """Create a ScenarioCover with relay feedback for testing."""
+    entity = ScenarioCover(mock_cover_with_relay, mock_ifsei)
+    entity.hass = hass
+    entity.entity_id = "cover.test_cover_relay"
+    await entity.async_added_to_hass()
+    return entity
+
+
+def test_properties_with_relay(scenario_cover_relay: ScenarioCover) -> None:
+    """Test properties for a cover with relay feedback."""
+    assert scenario_cover_relay.supported_features == (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.SET_POSITION
+    )
+    assert (
+        not hasattr(scenario_cover_relay, "assumed_state")
+        or not scenario_cover_relay.assumed_state
+    )
+    assert scenario_cover_relay.current_cover_position == 50  # noqa: PLR2004
+    assert scenario_cover_relay.is_opening is False
+    assert scenario_cover_relay.is_closing is False
+    assert scenario_cover_relay.is_closed is False  # position=50 != 0
+
+
+def test_open_relay_on(scenario_cover_relay: ScenarioCover) -> None:
+    """Test open_relay=100 sets is_opening and records timestamp."""
+    with patch.object(scenario_cover_relay, "async_write_ha_state") as mock_write:
+        scenario_cover_relay.async_update_callback(open_relay=100)
+        assert scenario_cover_relay.is_opening is True
+        assert scenario_cover_relay.is_closing is False
+        assert scenario_cover_relay._last_relay_on_time is not None
+        mock_write.assert_called_once()
+
+
+def test_open_relay_off_updates_position(scenario_cover_relay: ScenarioCover) -> None:
+    """Test open_relay=0 after being active calculates position delta."""
+    scenario_cover_relay._current_position = 0
+    scenario_cover_relay._is_opening = True
+    scenario_cover_relay._last_relay_on_time = (
+        scenario_cover_relay._travel_time
+    )  # fake start
+
+    with (
+        patch("custom_components.scenario.cover.time.time") as mock_time,
+        patch.object(scenario_cover_relay, "async_write_ha_state"),
+    ):
+        mock_time.return_value = scenario_cover_relay._travel_time + 15  # 15s elapsed
+        scenario_cover_relay.async_update_callback(open_relay=0)
+
+    # 15s / 30s * 100 = 50%
+    assert scenario_cover_relay._current_position == 50  # noqa: PLR2004
+    assert scenario_cover_relay.is_opening is False
+    assert scenario_cover_relay._last_relay_on_time is None
+
+
+def test_close_relay_on(scenario_cover_relay: ScenarioCover) -> None:
+    """Test close_relay=100 sets is_closing and records timestamp."""
+    with patch.object(scenario_cover_relay, "async_write_ha_state") as mock_write:
+        scenario_cover_relay.async_update_callback(close_relay=100)
+        assert scenario_cover_relay.is_closing is True
+        assert scenario_cover_relay.is_opening is False
+        assert scenario_cover_relay._last_relay_on_time is not None
+        mock_write.assert_called_once()
+
+
+def test_close_relay_off_updates_position(scenario_cover_relay: ScenarioCover) -> None:
+    """Test close_relay=0 after being active calculates position delta."""
+    scenario_cover_relay._current_position = 100
+    scenario_cover_relay._is_closing = True
+    scenario_cover_relay._last_relay_on_time = scenario_cover_relay._travel_time
+
+    with (
+        patch("custom_components.scenario.cover.time.time") as mock_time,
+        patch.object(scenario_cover_relay, "async_write_ha_state"),
+    ):
+        mock_time.return_value = (
+            scenario_cover_relay._travel_time + 30
+        )  # 30s = full close
+        scenario_cover_relay.async_update_callback(close_relay=0)
+
+    assert scenario_cover_relay._current_position == 0
+    assert scenario_cover_relay.is_closing is False
+    assert scenario_cover_relay.is_closed is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# **Explain how this PR changes scenario**

This PR adds physical relay-based position tracking for cover/shade entities, using the new `open_relay`/`close_relay` callbacks introduced in pyscenario 1.0.1. Previously, the integration had no way to track real cover position — it only knew the last command sent. Now, the duration the physical relay stays energised is used to calculate how far the cover has moved.

### Key changes

- **`cover.py`**: Rewrote `ScenarioCover` to handle `open_relay`/`close_relay` zone feedback signals. Position is calculated from elapsed time against `travel_time` (default 30 s). Extracted `_handle_open_relay`, `_handle_close_relay`, and `_handle_scene_command` helpers to keep `async_update_callback` lean.
- **`SET_POSITION` support**: Covers with relay feedback now expose `CoverEntityFeature.SET_POSITION`, using timed movement to reach the target.
- **`assumed_state`**: Restored for covers without relay feedback so HA keeps all buttons always enabled.
- **`manifest.json`**: Bumped integration version and pyscenario requirement to `1.0.1`.
- **`scenario_device_config.yaml`**: Added `module`, `open_channel`, `close_channel` for all 6 configured covers (Cortina, Persiana LD/LE sala, Persiana LD/LE quarto, Persiana Lateral).
- **`tests/test_cover.py`**: Updated existing tests to match new behaviour (explicit `module/open_channel/close_channel = None` on mock, corrected `is_closed` initial value, corrected `write_ha_state` call expectations). Added 6 new tests covering relay ON/OFF callbacks and relay-feedback properties.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.