### PR TITLE
fix(ci): align coverage cap with pytest-homeassistant-custom-component pin

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,6 @@
 pytest>=9.0.3
 pytest-asyncio>=1.3.0
 pytest-cov>=7.1.0
-pytest-homeassistant-custom-component>=0.13.333
-coverage>=7.5,<7.14
+pytest-homeassistant-custom-component>=0.13.335
+coverage>=7.5,<7.15
 mutmut>=3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.10.1
 homeassistant>=2024.6.0
-pip>=26.1.1
+pip>=26.1.2
 ruff==0.15.14
 pyscenario>=1.0.1
 pre-commit==4.6.0


### PR DESCRIPTION
## Problem

The **Test** CI job fails with `pip ResolutionImpossible` on `main` and on every open Dependabot PR (#169–#172). The job dies in ~15s during `pip install`, before any test runs.

Root cause: `pytest-homeassistant-custom-component` (the test harness) now hard-pins `coverage==7.14.0`, but `requirements.test.txt` capped `coverage>=7.5,<7.14`, making the dependency set unresolvable.

```
ERROR: Cannot install -r requirements.test.txt ... because these package versions have conflicting dependencies.
    The user requested coverage<7.14 and >=7.5
    pytest-homeassistant-custom-component 0.13.335 depends on coverage==7.14.0
```

The stale cap was introduced in #162 to match the harness's *then-current* coverage pin; the harness has since moved to 7.14.0.

## Fix

- `coverage>=7.5,<7.14` → `coverage>=7.5,<7.15` — allows the required 7.14.0 while keeping a ceiling (same convention as #162).

## Consolidated Dependabot bumps

This PR also folds in the two **valid** pending bumps that were only red because of the shared conflict above:

- `pytest-homeassistant-custom-component>=0.13.333` → `>=0.13.335` (supersedes #172)
- `pip>=26.1.1` → `pip>=26.1.2` (supersedes #170)

## Supersedes #169–#172

| PR | Change | Outcome |
|----|--------|---------|
| #170 | `pip>=26.1.2` | folded in |
| #172 | `phccc>=0.13.335` | folded in |
| #171 | `coverage>=7.14.1,<7.15` | unsatisfiable — phccc pins `coverage==7.14.0` |
| #169 | `pytest-asyncio>=1.4.0` | unsatisfiable — phccc pins `pytest-asyncio==1.3.0` |

`pytest-asyncio>=1.3.0` is intentionally left unchanged, as it already matches the harness's exact pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xs86At51VEGdMh5DRHtDov)_